### PR TITLE
Simplify argument checks

### DIFF
--- a/legacyman_parser/parser.py
+++ b/legacyman_parser/parser.py
@@ -52,12 +52,10 @@ def parse_from_root():
 
     # test_payload_for_parsed_json
     kw_args = dict(arg.split('=') for arg in sys.argv[2:])
-    test_payload_json = None
-    if 'test_payload_for_parsed_json' in kw_args:
-        test_payload_json = kw_args['test_payload_for_parsed_json']
-        if not os.path.isfile(test_payload_json):
-            print("Cannot find json test payload at {}".format(test_payload_json))
-            return
+    test_payload_json = kw_args.get('test_payload_for_parsed_json', None)
+    if test_payload_json is not None and not os.path.isfile(test_payload_json):
+        print("Cannot find json test payload at {}".format(test_payload_json))
+        return
 
     """Parsing Region
     The regions are processed from map"""


### PR DESCRIPTION
fixes #82 

Though not elegant as Java's, Python does have it methods to "provide" values if keys don't exist.

![image](https://user-images.githubusercontent.com/77854924/208732621-e14c3ad9-7ea7-44f8-8ed2-c180d007c869.png)
