### PR TITLE
Spruce up assert failure diagnostic messages

### DIFF
--- a/legacyman_parser/parse_abbreviations.py
+++ b/legacyman_parser/parse_abbreviations.py
@@ -21,13 +21,13 @@ def parse_abbreviations(soup: BeautifulSoup = None,
                     parent_url: str = None,
                     userland_dict: dict = None) -> []:
     assert len(soup.find_all('table')) == 1, "InvalidAssumption: There's going to be only one table in " \
-                                             "QuickLinksData/Abbreviations.html"
+                                             "QuickLinksData/Abbreviations.html => {}".format(parsed_url)
 
     compactor = []
     for abbrev_record in soup.find('table').find_all('tr'):
 
         assert len(abbrev_record.find_all('td')) == 4, "InvalidAssumption: Each row in this table contains " \
-                                                       "two key-value pairs, side-by-side"
+                                                       "two key-value pairs, side-by-side => {}".format(parsed_url)
 
         for abbr_data in abbrev_record.find_all('td'):
             compactor.append(abbr_data.text)

--- a/legacyman_parser/parse_tonals_of_class.py
+++ b/legacyman_parser/parse_tonals_of_class.py
@@ -51,8 +51,8 @@ def extract_tonals_of_class(soup: BeautifulSoup = None, parsed_url: str = None, 
     else:
         TONAL_HEADER_NOT_FOUND.append(parsed_url)
     assert TONAL_FOUND_FOR_CLASS.get(userland_dict['class'], False), "InvalidAssumption: Class ({}) page will " \
-                                                                     "have at least one tonal."\
-        .format(userland_dict['class'])
+                                                                     "have at least one tonal in page {}."\
+        .format(userland_dict['class'], parsed_url)
 
 
 def process_tonal_row(row: PageElement, class_u: any):

--- a/legacyman_parser/parser.py
+++ b/legacyman_parser/parser.py
@@ -243,11 +243,15 @@ def parse_from_root():
 
     # Assert assumptions on extracted data
     # Data assumption 1: Classes are unique for a given country and sub category
-    assert 1 == max(list(map(lambda grouped_values: len(list(grouped_values[1])), itertools.groupby(sorted(
+    count_extractor = lambda grouped_values: len(list(grouped_values[1]))
+    max_class_for_given_country_subcat = sorted(list(map(lambda a: (a[0], len(list(a[1]))), itertools.groupby(sorted(
         list(map(lambda a: a.country.country + "|" + a.sub_category[0] + "|" + a.class_u,
-                 standard_class_parser.CLASS_COLLECTION))), lambda a: a)))), "InvalidAssumption: " \
+                 standard_class_parser.CLASS_COLLECTION))), lambda a: a))), key=lambda a:a[1], reverse=True)[0]
+    assert 1 == max_class_for_given_country_subcat[1], "InvalidAssumption: " \
                                                                              "Classes are unique for a given " \
-                                                                             "country and sub category"
+                                                                             "country and sub category => {} has {} units"\
+                                                                             .format(max_class_for_given_country_subcat[0],
+                                                                                     max_class_for_given_country_subcat[1])
 
     if test_payload_json is not None:
         print("\n\nTest results:")

--- a/legacyman_parser/utils/parse_class_table.py
+++ b/legacyman_parser/utils/parse_class_table.py
@@ -25,9 +25,9 @@ class ClassParser:
         self._current_subtype_id = None
         self.classRowExtractor = userland_dict.get('class_extractor')
         class_h1 = soup.find_all('h1')
-        assert len(class_h1) == 1, "InvalidAssumption: Each ns country page contains only 1 h1 header"
+        assert len(class_h1) == 1, "InvalidAssumption: Each ns country page contains only 1 h1 header => {}".format(parsed_url)
         class_subtypes_list = class_h1[0].find_next_siblings('div')
-        assert len(class_subtypes_list) >= 1, "InvalidAssumption: Each ns class listing has one or more entries"
+        assert len(class_subtypes_list) >= 1, "InvalidAssumption: Each ns class listing has one or more entries => {}".format(parsed_url)
         for ns_sub_type in class_subtypes_list:
             sub_type_url = urljoin(parsed_url, ns_sub_type.find('a')['href'])
             ns_country_spidey_to_extract_classes = SimpleCrawler(url=sub_type_url,
@@ -45,24 +45,24 @@ class ClassParser:
         self._current_subtype_id = None
         class_list_all = soup.find_all('div', {"id": "PageLayer"})
         assert len(class_list_all) == 1, "InvalidAssumption: Each country page contains only 1 PageLayer div" \
-                                         " that lists classes."
+                                         " that lists classes. => {}".format(parsed_url)
         class_list = class_list_all[0]
         if class_list:
             table_list = class_list.find_all('table')
-            assert len(table_list) == 1, "InvalidAssumption: PageLayer div contains only 1 table of classes"
+            assert len(table_list) == 1, "InvalidAssumption: PageLayer div contains only 1 table of classes => {}".format(parsed_url)
             rows = table_list[0].find_all('tr')
             self._current_subtype_id = self.create_sub_type_id_of_ns_class(rows[0],
-                                                                           userland_dict.get('country').country)
+                                                                           userland_dict.get('country').country, parsed_url)
             for row in rows[1:]:
                 self.process_class_row(row, userland_dict['country'], parsed_url)
         else:
             self.NON_STANDARD_COUNTRY.append(parsed_url)
         assert self._class_table_header_is_identified, "InvalidAssumption: Class Table will mandatorily have table header with " \
-                                                       "its first column header as text Class (case sensitive)"
+                                                       "its first column header as text Class (case sensitive) => {}".format(parsed_url)
         assert self.CLASS_FOUND_FOR_COUNTRY.get(userland_dict['country'],
                                                 False), "InvalidAssumption: Country ({}) page will " \
-                                                        "have at least one class." \
-            .format(userland_dict['country'])
+                                                        "have at least one class. => {}" \
+            .format(userland_dict['country'], parsed_url)
 
     def extract_classes_of_country(self, soup: BeautifulSoup = None, parsed_url: str = None, parent_url: str = None,
                                    userland_dict: dict = None) -> []:
@@ -71,22 +71,22 @@ class ClassParser:
         self.classRowExtractor = userland_dict.get('class_extractor')
         class_list_all = soup.find_all('div', {"id": "PageLayer"})
         assert len(class_list_all) == 1, "InvalidAssumption: Each country page contains only 1 PageLayer div" \
-                                         " that lists classes."
+                                         " that lists classes. => {}".format(parsed_url)
         class_list = class_list_all[0]
         if class_list:
             table_list = class_list.find_all('table')
-            assert len(table_list) == 1, "InvalidAssumption: PageLayer div contains only 1 table of classes"
+            assert len(table_list) == 1, "InvalidAssumption: PageLayer div contains only 1 table of classes => {}".format(parsed_url)
             for row in table_list[0].find_all('tr'):
                 self.process_class_row(row, userland_dict['country'], parsed_url)
         else:
             self.NON_STANDARD_COUNTRY.append(parsed_url)
         assert self._class_table_header_is_identified, "InvalidAssumption: Class Table will mandatorily have " \
                                                        "table header with its first column header as text " \
-                                                       "Class (case sensitive)"
+                                                       "Class (case sensitive) => {}".format(parsed_url)
         assert self.CLASS_FOUND_FOR_COUNTRY.get(userland_dict['country'],
                                                 False), "InvalidAssumption: Country ({}) page will " \
-                                                        "have at least one class." \
-            .format(userland_dict['country'])
+                                                        "have at least one class. => {}" \
+            .format(userland_dict['country'], parsed_url)
 
     def process_class_row(self, row: PageElement, country: dict, parsed_url: str):
         """Check if not _class_table_header_is_identified"""
@@ -117,15 +117,15 @@ class ClassParser:
         self.SUBTYPE_COLLECTION[sub_type] = new_id
         return sub_type, new_id
 
-    def create_sub_type_id_of_ns_class(self, sub_type_str: str, country):
+    def create_sub_type_id_of_ns_class(self, sub_type_str: str, country, parsed_url):
         beginswith = "Overview of "
         endswith = " in " + country
         assert sub_type_str.text.strip().startswith(beginswith), "InvalidAssumption: Subtype identification " \
                                                                  "of classes of non-standard countries does not" \
-                                                                 "begin with 'Overview of'"
+                                                                 "begin with 'Overview of' => {}".format(parsed_url)
         assert sub_type_str.text.strip().endswith(endswith), "InvalidAssumption: Subtype identification " \
                                                              "of classes of non-standard countries does not" \
-                                                             "end with ' in Country'"
+                                                             "end with ' in Country' => {}".format(parsed_url)
         sub_type = sub_type_str.text.strip().replace(beginswith, "").replace(endswith, "")
         if sub_type in self.SUBTYPE_COLLECTION:
             return sub_type, self.SUBTYPE_COLLECTION[sub_type]


### PR DESCRIPTION
Provided additional diagnostic messages to pinpoint where the error occurs.
For assertions on consolidated/grouping operations, the failing data points are provided, instead of the html file locations.