### PR TITLE
introduce example with multiple quick links tables

### DIFF
--- a/data/Wales_Composite/unit_ab.html
+++ b/data/Wales_Composite/unit_ab.html
@@ -9,14 +9,14 @@
           <td>content 4</td>
         </tr>
         <tr>
-          <td><a href="unit_split_b.html">Remarks</a></td>
+          <td><a href="#number2">Remarks</a></td>
           <td>Propulsion</td>
           <td></td>
           <td></td>
         </tr>
       </table>
     </div>
-    <h1>PROPULSION SYSTEM</h1>
+    <h1><a name="number3">PROPULSION SYSTEM</a></h1>
     <p></p>
     <p></p>
     <p></p>
@@ -62,6 +62,22 @@
 </div>
 <div id="BottomLayer">
   <div id="PageLayer">
+    <div id="QuickLinksTable">
+      <table border="1">
+        <tr>
+          <td>some content</td>
+          <td>content 2</td>
+          <td>content 3</td>
+          <td>content 4</td>
+        </tr>
+        <tr>
+          <td><a href="#number2">Remarks</a></td>
+          <td><a href="#number3">Propulsion</a></td>
+          <td></td>
+          <td></td>
+        </tr>
+      </table>
+    </div>
     <div id="Table">
       <table border="1">
         <tr>
@@ -167,14 +183,14 @@
       </tr>
       <tr>
         <td>Remarks</td>
-        <td><a href="#number2">Propulsion</a></td>
+        <td><a href="#number3">Propulsion</a></td>
         <td></td>
         <td></td>
       </tr>
     </table>
   </div>
   <div id="PageLayer2">
-    <h1>REMARKS</h1>
+    <h1><a name="number2">REMARKS</a></h1>
     <div name="image9" id="image9">
       <img src="./Content/Images/unit_a1.jpg" />&nbsp;<img
         src="./Content/Images/unit_a2.jpeg"

--- a/data/Wales_Composite/unit_ab.html
+++ b/data/Wales_Composite/unit_ab.html
@@ -1,144 +1,189 @@
 <div id="BottomLayer3">
-    <div id="PageLayer3">
-        <h1>PROPULSION SYSTEM</h1>
-        <p></p>
-        <p></p>
-        <p></p>
-        <p></p>
-        <p></p>
-        <p></p>
-        <div>
-            <table border="1">
-                <tr>
-                    <td colspan="4"><strong>Unit_A Wales</strong></td>
-                </tr>
-                <tr>
-                    <td><strong>Cruise Plant</strong></td>
-                    <td>4 * PR32 Diesel Engines</td>
-                    <td><strong>Shaft x Blade</strong></td>
-                    <td>2 * 4 (GRR)</td>
-                </tr>
-                <tr>
-                    <td rowspan="2"><strong>Boost Plant</strong></td>
-                    <td rowspan="2">None</td>
-                    <td><strong>MTBF</strong></td>
-                    <td>14hrs & 12 ltr/hr</td>
-                </tr>
-                <tr>
-                    <td><strong>BHP</strong></td>
-                    <td>400 hrs</td>
-                </tr>
-                <tr>
-                    <td><strong>Reduction Ratio</strong></td>
-                    <td>412.8:1</td>
-                    <td><strong>Av Temp</strong></td>
-                    <td>~14</td>
-                </tr>
-                <tr>
-                    <td><strong>Max TRPM</strong></td>
-                    <td>1400</td>
-                    <td><strong>Max SRPM</strong></td>
-                    <td>0-1600</td>
-                </tr>
-            </table>
-        </div>
+  <div id="PageLayer3">
+    <div id="QuickLinksTable">
+      <table border="1">
+        <tr>
+          <td>some content</td>
+          <td>content 2</td>
+          <td>content 3</td>
+          <td>content 4</td>
+        </tr>
+        <tr>
+          <td><a href="unit_split_b.html">Remarks</a></td>
+          <td>Propulsion</td>
+          <td></td>
+          <td></td>
+        </tr>
+      </table>
     </div>
+    <h1>PROPULSION SYSTEM</h1>
+    <p></p>
+    <p></p>
+    <p></p>
+    <p></p>
+    <p></p>
+    <p></p>
+    <div>
+      <table border="1">
+        <tr>
+          <td colspan="4"><strong>Unit_A Wales</strong></td>
+        </tr>
+        <tr>
+          <td><strong>Cruise Plant</strong></td>
+          <td>4 * PR32 Diesel Engines</td>
+          <td><strong>Shaft x Blade</strong></td>
+          <td>2 * 4 (GRR)</td>
+        </tr>
+        <tr>
+          <td rowspan="2"><strong>Boost Plant</strong></td>
+          <td rowspan="2">None</td>
+          <td><strong>MTBF</strong></td>
+          <td>14hrs & 12 ltr/hr</td>
+        </tr>
+        <tr>
+          <td><strong>BHP</strong></td>
+          <td>400 hrs</td>
+        </tr>
+        <tr>
+          <td><strong>Reduction Ratio</strong></td>
+          <td>412.8:1</td>
+          <td><strong>Av Temp</strong></td>
+          <td>~14</td>
+        </tr>
+        <tr>
+          <td><strong>Max TRPM</strong></td>
+          <td>1400</td>
+          <td><strong>Max SRPM</strong></td>
+          <td>0-1600</td>
+        </tr>
+      </table>
+    </div>
+  </div>
 </div>
 <div id="BottomLayer">
-    <div id="PageLayer">
-        <div id="Table">
-            <table border="1">
-                <tr>
-                    <td>Drive</td>
-                    <td>Mode</td>
-                    <td>Shaft x Blade</td>
-                    <td>R:R</td>
-                    <td>BHP</td>
-                    <td>Av Temp (Guide)</td>
-                </tr>
-                <tr>
-                    <td>4 Diesel</td>
-                    <td>PTR</td>
-                    <td>2 * 4 (GRR)</td>
-                    <td>412.8:1</td>
-                    <td>400 hrs</td>
-                    <td>~14</td>
-                </tr>
-                <tr>
-                    <td colspan="6"><strong>Commonly Detected Sources</strong></td>
-                </tr>
-                <tr>
-                    <td>Source</td>
-                    <td>Ratio/Freq</td>
-                    <td colspan="2">Harmonics</td>
-                    <td colspan="2">Remarks</td>
-                </tr>
-                <tr>
-                    <td colspan="6">Power Related</td>
-                </tr>
-                <tr>
-                    <td>SR</td>
-                    <td>S12</td>
-                    <td colspan="2">H1-4</td>
-                    <td colspan="2">Discrete. Doublets common</td>
-                </tr>
-                <tr>
-                    <td>BR</td>
-                    <td>S5</td>
-                    <td colspan="2">H1</td>
-                    <td colspan="2">Discrete. Doublets common</td>
-                </tr>
-                <tr>
-                    <td colspan="6">Auxiliary Sources</td>
-                </tr>
-                <tr>
-                    <td>Cat b Engine R</td>
-                    <td>2-1000.4</td>
-                    <td colspan="2">H2, 4, 21, 145</td>
-                    <td colspan="2">The quick brown fox does something similar <a href="../France_Legacy/France_Legacy_Pics.html#number4">Tool screenshot a</a><a href="../France_Legacy/France_Legacy_Pics.html#number3">Tool screenshot b</a></td>
-                </tr>
-                <tr>
-                    <td>Unk BBA</td>
-                    <td>25 & CSR</td>
-                    <td colspan="2">H1</td>
-                    <td colspan="2">CBR 34</td>
-                </tr>
-                <tr>
-                    <td colspan="6">Transient Sources</td>
-                </tr>
-                <tr>
-                    <td>Unk BBA</td>
-                    <td>135 & CSR</td>
-                    <td colspan="2">H1 & 2</td>
-                    <td colspan="2">CBR 54334</td>
-                </tr>
-                <tr>
-                    <td colspan="6">Signature & Characteristics</td>
-                </tr>
-                <tr>
-                    <td>Acoustic Signature</td>
-                    <td colspan="5">Expect plant to be similar to 2016 steam powered version</td>
-                </tr>
-                <tr>
-                    <td>Unique classifiers</td>
-                    <td colspan="5">None</td>
-                </tr>
-                <tr>
-                    <td>Aural</td>
-                    <td colspan="5">Expect Diesel, Whine, Governor release</td>
-                </tr>
-            </table>
-        </div>
+  <div id="PageLayer">
+    <div id="Table">
+      <table border="1">
+        <tr>
+          <td>Drive</td>
+          <td>Mode</td>
+          <td>Shaft x Blade</td>
+          <td>R:R</td>
+          <td>BHP</td>
+          <td>Av Temp (Guide)</td>
+        </tr>
+        <tr>
+          <td>4 Diesel</td>
+          <td>PTR</td>
+          <td>2 * 4 (GRR)</td>
+          <td>412.8:1</td>
+          <td>400 hrs</td>
+          <td>~14</td>
+        </tr>
+        <tr>
+          <td colspan="6"><strong>Commonly Detected Sources</strong></td>
+        </tr>
+        <tr>
+          <td>Source</td>
+          <td>Ratio/Freq</td>
+          <td colspan="2">Harmonics</td>
+          <td colspan="2">Remarks</td>
+        </tr>
+        <tr>
+          <td colspan="6">Power Related</td>
+        </tr>
+        <tr>
+          <td>SR</td>
+          <td>S12</td>
+          <td colspan="2">H1-4</td>
+          <td colspan="2">Discrete. Doublets common</td>
+        </tr>
+        <tr>
+          <td>BR</td>
+          <td>S5</td>
+          <td colspan="2">H1</td>
+          <td colspan="2">Discrete. Doublets common</td>
+        </tr>
+        <tr>
+          <td colspan="6">Auxiliary Sources</td>
+        </tr>
+        <tr>
+          <td>Cat b Engine R</td>
+          <td>2-1000.4</td>
+          <td colspan="2">H2, 4, 21, 145</td>
+          <td colspan="2">
+            The quick brown fox does something similar
+            <a href="../France_Legacy/France_Legacy_Pics.html#number4"
+              >Tool screenshot a</a
+            ><a href="../France_Legacy/France_Legacy_Pics.html#number3"
+              >Tool screenshot b</a
+            >
+          </td>
+        </tr>
+        <tr>
+          <td>Unk BBA</td>
+          <td>25 & CSR</td>
+          <td colspan="2">H1</td>
+          <td colspan="2">CBR 34</td>
+        </tr>
+        <tr>
+          <td colspan="6">Transient Sources</td>
+        </tr>
+        <tr>
+          <td>Unk BBA</td>
+          <td>135 & CSR</td>
+          <td colspan="2">H1 & 2</td>
+          <td colspan="2">CBR 54334</td>
+        </tr>
+        <tr>
+          <td colspan="6">Signature & Characteristics</td>
+        </tr>
+        <tr>
+          <td>Acoustic Signature</td>
+          <td colspan="5">
+            Expect plant to be similar to 2016 steam powered version
+          </td>
+        </tr>
+        <tr>
+          <td>Unique classifiers</td>
+          <td colspan="5">None</td>
+        </tr>
+        <tr>
+          <td>Aural</td>
+          <td colspan="5">Expect Diesel, Whine, Governor release</td>
+        </tr>
+      </table>
     </div>
+  </div>
 </div>
 <div id="BottomLayer2">
-    <div id="PageLayer2">
-        <h1>REMARKS</h1>
-        <div name="image9" id="image9"><img src="./Content/Images/unit_a1.jpg">&nbsp;<img src="./Content/Images/unit_a2.jpeg"></div>
-        <p></p>
-        <p></p>
-        <p>1. The alphabet is already in alphabetical order one</p>
-        <p>2. The alphabet is already in alphabetical order two</p>
-        <p>3. The alphabet is already in alphabetical order three</p>
+  <div id="QuickLinksTable">
+    <table border="1">
+      <tr>
+        <td>some content</td>
+        <td>content 2</td>
+        <td>content 3</td>
+        <td>content 4</td>
+      </tr>
+      <tr>
+        <td>Remarks</td>
+        <td><a href="#number2">Propulsion</a></td>
+        <td></td>
+        <td></td>
+      </tr>
+    </table>
+  </div>
+  <div id="PageLayer2">
+    <h1>REMARKS</h1>
+    <div name="image9" id="image9">
+      <img src="./Content/Images/unit_a1.jpg" />&nbsp;<img
+        src="./Content/Images/unit_a2.jpeg"
+      />
     </div>
+    <p></p>
+    <p></p>
+    <p>1. The alphabet is already in alphabetical order one</p>
+    <p>2. The alphabet is already in alphabetical order two</p>
+    <p>3. The alphabet is already in alphabetical order three</p>
+  </div>
 </div>


### PR DESCRIPTION
Supports #196 

This adds several QuickLinksTables to a page.  We have to loop through the tables to find one with a clickable Propulsion entry.