### PR TITLE
222 cleanse ref ids

### DIFF
--- a/legacy_publisher/json_publisher.py
+++ b/legacy_publisher/json_publisher.py
@@ -5,8 +5,7 @@ import random
 from legacy_publisher.json_templates import PlatformType, PropulsionType, PlatformSubType, Region, Country, ClassU, \
     TonalType, Tonal, TonalSource
 from legacyman_parser.utils.constants import JSON_EXPORT_FILE
-from legacyman_parser.utils.ref_id_generator import classes_with_illegal_reference_id_characters, \
-    get_audited_ref_id_for_class
+from legacyman_parser.utils.ref_id_generator import get_cleansed_ref_id_for_class
 
 """This module will handle post parsing enhancements for publishing"""
 
@@ -56,7 +55,7 @@ def publish(parsed_regions=None, parsed_countries=None, parsed_classes=None, par
         classes.append(
             ClassU(class_u.id, class_u.class_u, class_u.sub_category[1], class_u.country.id, None, class_u.power,
                    None, None, None, None, None, None, None, image_array_react_image_gallery,
-                   get_audited_ref_id_for_class(class_u)))
+                   get_cleansed_ref_id_for_class(class_u)))
 
     # Extract tonal types
     tonal_types = []
@@ -87,11 +86,6 @@ def publish(parsed_regions=None, parsed_countries=None, parsed_classes=None, par
                  "countries": countries, "propulsion_types": [propulsion_type], "units": classes,
                  "tonal_sources": tonal_sources, "tonal_types": tonal_types, "tonals": tonals,
                  "abbreviations": parsed_abbreviations, "flags": [], "class_images": []}
-
-    if len(classes_with_illegal_reference_id_characters) > 0:
-        print("\n\n\nThe following classes were found with illegal characters")
-        for class_ref_id in classes_with_illegal_reference_id_characters:
-            print("  ", class_ref_id)
 
     # Dump the wrapper to the text file passed as argument
     with open(EXPORT_FILE, 'w') as f:

--- a/legacyman_parser/utils/ref_id_generator.py
+++ b/legacyman_parser/utils/ref_id_generator.py
@@ -1,25 +1,21 @@
 import re
 
-# Name to start with alphabet, and then should contain one
-# or more of the following characters
-# a to z
-# 0 to 9
-# - (hyphen)
-# _ (underscore)
-accepted_ref_id_pattern = re.compile(r"^[a-z][a-z0-9-_]+$")
-
-classes_with_illegal_reference_id_characters = []
+valid_characters_pattern = re.compile('[^0-9a-z_-]+')
 
 
 def get_ref_id_for_class(classu):
     # TODO: Introduce string shortening logic
-    return (classu.country.country + ":"
-            + classu.sub_category[0] + ":"
-            + classu.class_u).lower().replace(" ", "_").replace(":", "-")
+    return (classu.country.country + "-"
+            + classu.sub_category[0] + "-"
+            + classu.class_u).lower() \
+        .replace(" ", "_") \
+        .replace("/", "-") \
+        .replace("\\", "-") \
+        .replace("(", "-") \
+        .replace(")", "-") \
+        .replace("&", "-")
 
 
-def get_audited_ref_id_for_class(classu):
+def get_cleansed_ref_id_for_class(classu):
     ref_id = get_ref_id_for_class(classu)
-    if accepted_ref_id_pattern.match(ref_id) is None:
-        classes_with_illegal_reference_id_characters.append(ref_id)
-    return ref_id
+    return re.sub(valid_characters_pattern, '', ref_id)

--- a/target/data/publication.js
+++ b/target/data/publication.js
@@ -178,7 +178,7 @@ var publicationJsonData={
           "url": "images/class_images/narnia/generic/legacy/new-test-48.jpg"
         }
       ],
-      "ref_id": "narnia-legacy-*unit_d"
+      "ref_id": "narnia-legacy-unit_d"
     },
     {
       "id": 5,
@@ -375,7 +375,7 @@ var publicationJsonData={
           "url": "images/class_images/spain/generic/legacy/test-48_1.jpg"
         }
       ],
-      "ref_id": "spain-legacy-*unit_db"
+      "ref_id": "spain-legacy-unit_db"
     },
     {
       "id": 14,
@@ -559,7 +559,7 @@ var publicationJsonData={
       "tpk": null,
       "max_rpm": null,
       "images": [],
-      "ref_id": "iceland-complex-unit_a%test-106_icelandic_complex%"
+      "ref_id": "iceland-complex-unit_atest-106_icelandic_complex"
     },
     {
       "id": 23,
@@ -604,7 +604,7 @@ var publicationJsonData={
           "url": "images/class_images/iceland/generic/composite/unit_a2.jpeg"
         }
       ],
-      "ref_id": "iceland-composite-unit_ab%test-106_icelandic_composite%"
+      "ref_id": "iceland-composite-unit_abtest-106_icelandic_composite"
     },
     {
       "id": 25,


### PR DESCRIPTION
fixes #222 

@IanMayo, I've removed the diagnostics showing filenames with illegal characters since we're taking affirmative action against such characters. Please review.