### PR TITLE
destination links all lower-case

### DIFF
--- a/parser/parser.py
+++ b/parser/parser.py
@@ -284,7 +284,7 @@ def process_category_pages(
                         class_file_src_path, class_file_target_path, class_name, file_name
                     )
 
-                    file_link = a["href"].replace(".html", ".dita")
+                    file_link = a["href"].replace(".html", ".dita").lower()
                     dita_xref["href"] = f"./{file_link}"
 
                 dita_xref.string = a.text.strip()


### PR DESCRIPTION
We can encounter links in a class-listing table - sometimes they occupy the full width of the row.

When we re-create the target link (with suffix converted to DITA), it should be lower case.

Have tried this fix against the real data, and it fixes the issue.