### PR TITLE
introduce URLs with in-page anchors

### DIFF
--- a/data/Britain.Legacy/100_unit_charlie.html
+++ b/data/Britain.Legacy/100_unit_charlie.html
@@ -434,7 +434,7 @@
                               <td width="18%" align="center" bgcolor="#66CCFF"><strong>Quick Links</strong></td>
                               <td width="18%" align="center"><a href="#number3">Signature</a></td>
                               <td width="18%" align="center"><a href="Phase_G_Size.html">Remarks</a> / <a href="Phase_G_Size.html#number2">Systems</a></td>
-                              <td width="18%" align="center"><a href="../QuickLinksData/Vanes&Cranes.html">Vanity Sources</a></td>
+                              <td width="18%" align="center"><a href="../QuickLinksData/Vanes&Cranes.html#number2">Vanity Sources</a></td>
                             </tr>
                             <tr>
                               <td width="18%" align="center"><a href="Content/Legacy HeatCalculator.xlsx">Heat calculator</a></td>

--- a/data/Britain1/Britain1.html
+++ b/data/Britain1/Britain1.html
@@ -3,7 +3,7 @@
     <table border="1">
       <tr>
         <td><strong>Quick Links</strong>></td>
-        <td><a href="../QuickLinksData/Vanes&Cranes.html"><img src="./Content/Images/FlagS.jpg" />Vanes</a></td>
+        <td><a href="../QuickLinksData/Vanes&Cranes.html#number2"><img src="./Content/Images/FlagS.jpg" />Vanes</a></td>
       </tr>
       <tr>
         <td><a href="../QuickLinksData/Abbreviations.html">Abbreviations</a></td>

--- a/data/Wight&Man/Wight&M.html
+++ b/data/Wight&Man/Wight&M.html
@@ -50,7 +50,7 @@
                 </tr>
                 <tr>
                     <td width="18%" align="center"><a href="../QuickLinksData/Abbreviations.html">Abbreviations</a></td>
-                    <td width="18%" align="center"><a href="../QuickLinksData/Vanes&Cranes.html">Vanes & Cranes</a></td>
+                    <td width="18%" align="center"><a href="../QuickLinksData/Vanes&Cranes.html#number2">Vanes & Cranes</a></td>
                 </tr>
             </table>
         </div>

--- a/parser/lman_parser.py
+++ b/parser/lman_parser.py
@@ -491,7 +491,8 @@ class Parser:
         input_file_directory = input_file_path.parent
 
         for _, href in quicklinks.items():
-            link_path = (input_file_directory / href).resolve()
+            clean_href = href.split("#")[0]
+            link_path = (input_file_directory / clean_href).resolve()
             if link_path.exists():
                 self.process_generic_file(link_path)
             else:


### PR DESCRIPTION
We have a category listing page with QuickLinks that include a target with an anchor in the URL.

This is breaking the `path.exists` checking that we're doing:
![image](https://github.com/DeepBlueCLtd/LegacyMan/assets/1108513/ded20032-15df-4427-97fd-5183447fcfd4)

The issue is fixed in this PR.
