### PR TITLE
Adding COMMERCIALLY header and footer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ share/python-wheels/
 .installed.cfg
 *.egg
 MANIFEST
+target/
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/template/F13ldMan/oxygen.css
+++ b/template/F13ldMan/oxygen.css
@@ -3,6 +3,42 @@
  * Skin for oXygen generated WebHelp.
  * ==============================================
  */
+
+/* user-defined CSS */
+
+
+.wh_footer_commercial{
+    text-align: center;
+    padding: 1em;
+    position:relative;
+    bottom: 0;
+    width: 100%;
+    color: #000;
+    background: none #bfebb9;
+    top: 2em;
+}
+
+.wh_footer_commercial span{
+    font-family: Arial;
+    font-size: 14px;
+}
+
+.wh_header_commercial{
+    background: #bfebb9 none;
+    color: #000;
+    text-align: center;
+}
+
+.wh_header_commercial span{
+    font-family: Arial;
+    font-size: 14px;
+}
+
+
+
+/* ------------------------------------------- */
+
+
 /* don't show section title anchro */
 .permalink {
     display: none

--- a/template/F13ldMan/page-templates/footer.xml
+++ b/template/F13ldMan/page-templates/footer.xml
@@ -1,6 +1,13 @@
-<footer class="navbar navbar-default wh_footer" xmlns="http://www.w3.org/1999/xhtml"
-  xmlns:whc="http://www.oxygenxml.com/webhelp/components">
-  <div class=" footer-container mx-auto ">
-    <whc:include_html href="${webhelp.fragment.footer}"/>
-  </div>
-</footer>
+<div>
+  <footer class="navbar navbar-default wh_footer_commercial" xmlns="http://www.w3.org/1999/xhtml" xmlns:whc="http://www.oxygenxml.com/webhelp/components">
+    <div class=" footer-container mx-auto ">
+      <span>COMMERCIALLY SENSITIVE</span>
+    </div>
+  </footer>
+  <footer class="navbar navbar-default wh_footer" xmlns="http://www.w3.org/1999/xhtml" xmlns:whc="http://www.oxygenxml.com/webhelp/components">
+    <div class=" footer-container mx-auto ">
+      <whc:include_html href="${webhelp.fragment.footer}"/>
+    </div>
+  </footer>
+  
+</div>

--- a/template/F13ldMan/page-templates/footer.xml
+++ b/template/F13ldMan/page-templates/footer.xml
@@ -3,11 +3,5 @@
     <div class=" footer-container mx-auto ">
       <span>COMMERCIALLY SENSITIVE</span>
     </div>
-  </footer>
-  <footer class="navbar navbar-default wh_footer" xmlns="http://www.w3.org/1999/xhtml" xmlns:whc="http://www.oxygenxml.com/webhelp/components">
-    <div class=" footer-container mx-auto ">
-      <whc:include_html href="${webhelp.fragment.footer}"/>
-    </div>
-  </footer>
-  
+  </footer>  
 </div>

--- a/template/F13ldMan/page-templates/header.xml
+++ b/template/F13ldMan/page-templates/header.xml
@@ -1,31 +1,33 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<header class="navbar navbar-default wh_header"
-     xmlns="http://www.w3.org/1999/xhtml"
-     xmlns:whc="http://www.oxygenxml.com/webhelp/components">
-    <div class="container-fluid">
-        <div class="wh_header_flex_container navbar-nav navbar-expand-md navbar-dark">
-            <div class="wh_logo_and_publication_title_container">
-                <div class="wh_logo_and_publication_title">
-                    <whc:include_html href="${webhelp.fragment.before.logo_and_title}"/>
-                    <whc:webhelp_logo class="d-none d-sm-block"/>
-                    <whc:webhelp_publication_title/>
-                    <whc:include_html href="${webhelp.fragment.after.logo_and_title}"/>
-                </div>
-                
-                <button type="button" data-target="#wh_top_menu_and_indexterms_link" id="wh_menu_mobile_button" 
-                    data-toggle="collapse" class="navbar-toggler collapsed wh_toggle_button"
-                    aria-expanded="false" aria-label="${i18n(toggle.menu)}"
-                    aria-controls="wh_top_menu_and_indexterms_link">
-                    <span class="navbar-toggler-icon"></span>
-                </button>
-            </div>
+<div>
+    <header class="navbar navbar-default wh_header_commercial" xmlns="http://www.w3.org/1999/xhtml" xmlns:whc="http://www.oxygenxml.com/webhelp/components">
+        <div class="header-container mx-auto">
+            <span>COMMERCIALLY SENSITIVE</span>
+        </div>
+    </header>
+    <header class="navbar navbar-default wh_header" xmlns="http://www.w3.org/1999/xhtml" xmlns:whc="http://www.oxygenxml.com/webhelp/components">
+        <div class="container-fluid">
+            <div class="wh_header_flex_container navbar-nav navbar-expand-md navbar-dark">
+                <div class="wh_logo_and_publication_title_container">
+                    <div class="wh_logo_and_publication_title">
+                        <whc:include_html href="${webhelp.fragment.before.logo_and_title}"/>
+                        <whc:webhelp_logo class="d-none d-sm-block"/>
+                        <whc:webhelp_publication_title/>
+                        <whc:include_html href="${webhelp.fragment.after.logo_and_title}"/>
+                    </div>
 
-            <div class="wh_top_menu_and_indexterms_link collapse navbar-collapse" id="wh_top_menu_and_indexterms_link">
-                <whc:include_html href="${webhelp.fragment.before.top_menu}"/>
-                <whc:webhelp_top_menu />
-                <whc:webhelp_indexterms_link/>
-                <whc:include_html href="${webhelp.fragment.after.top_menu}"/>
+                    <button type="button" data-target="#wh_top_menu_and_indexterms_link" id="wh_menu_mobile_button" data-toggle="collapse" class="navbar-toggler collapsed wh_toggle_button" aria-expanded="false" aria-label="${i18n(toggle.menu)}" aria-controls="wh_top_menu_and_indexterms_link">
+                        <span class="navbar-toggler-icon"/>
+                    </button>
+                </div>
+
+                <div class="wh_top_menu_and_indexterms_link collapse navbar-collapse" id="wh_top_menu_and_indexterms_link">
+                    <whc:include_html href="${webhelp.fragment.before.top_menu}"/>
+                    <whc:webhelp_top_menu/>
+                    <whc:webhelp_indexterms_link/>
+                    <whc:include_html href="${webhelp.fragment.after.top_menu}"/>
+                </div>
             </div>
         </div>
-    </div>
-</header>
+    </header>
+</div>


### PR DESCRIPTION
Commercial information is now added to the header and footer section. The available header.xml and footer.xml from the template were used. Also copied available CSS information and created 2 new CSS styles. The commercial areas are implemented statically. To switch them on and off, need to implement https://github.com/DeepBlueCLtd/Fi3ldMan/issues/89


Fixes https://github.com/DeepBlueCLtd/Fi3ldMan/issues/88
Fixes https://github.com/DeepBlueCLtd/Fi3ldMan/issues/91