### PR TITLE
Warn about repeated blank space in files

### DIFF
--- a/parser/check_files.py
+++ b/parser/check_files.py
@@ -21,6 +21,14 @@ def search_for_strings(html_soup, output):
             search_for_strings(element, output)
 
 
+def random_substring(s, n=30):
+    length = len(s)
+
+    start_char = random.randint(0, length - 30)
+
+    return s[start_char : start_char + n]
+
+
 def select_random_text_from_file(path, n):
     html = Path(path).read_text()
     html_soup = BeautifulSoup(html, "html.parser")
@@ -29,6 +37,9 @@ def select_random_text_from_file(path, n):
     search_for_strings(html_soup, output)
 
     output = list(filter(lambda x: len(x) > 40, output))
+
+    # Get a random substring of each string
+    output = list(map(random_substring, output))
 
     if n == "all":
         return output

--- a/parser/lman_parser.py
+++ b/parser/lman_parser.py
@@ -574,25 +574,24 @@ class Parser:
             else:
                 return False
 
-        def next_sibling_tag(el):
-            next_sib = el.next_sibling
-            while type(next_sib) is bs4.element.NavigableString:
-                next_sib = next_sib.next_sibling
-
-            return next_sib
-
         # Check for repeated <p>&nbsp;</p> elements
         p_elements = page.find_all("p")
         empty_p_elements = list(filter(is_empty_p_element, p_elements))
-
         found = False
         for el in empty_p_elements:
             count = 0
-            while is_empty_p_element(next_sibling_tag(el)):
-                count += 1
+            for next_sibling in el.next_siblings:
+                if next_sibling is None:
+                    break
+                elif type(next_sibling) is bs4.element.NavigableString:
+                    continue
+                elif is_empty_p_element(next_sibling):
+                    count += 1
+
                 if count >= 4:
                     found = True
                     break
+
             if found:
                 logging.warning(
                     f"Found string of repeated <p>&nbsp;</p> elements in div with ID {page.get('id')} in file {filename}"

--- a/parser/parser_utils.py
+++ b/parser/parser_utils.py
@@ -191,9 +191,9 @@ def generate_top_to_div_mapping(
     # exited in an earlier if statement), so we check if there are some elements without top values
     # and raise a warning if so
     if len(elements_without_top_value) > 0 and len(html_soup.find_all(recursive=False)) > 1:
-        logging.warning(
-            f"Elements with no top value found inside element with ID {html_soup.get('id')} in file {filename}"
-        )
+        # logging.warning(
+        #     f"Elements with no top value found inside element with ID {html_soup.get('id')} in file {filename}"
+        # )
         return [(0, html_soup)]
 
     return top_to_div_mapping


### PR DESCRIPTION
Fixes #548.

This also removes the old warning that we were using to detect content that was mixed with top and no top values, but leaves the logic in there in case we need to re-enable it later.