### PR TITLE
Store link tracker dict in link_tracker.json and use later + CLI arg parsing improvements

### DIFF
--- a/parser/lman_parser.py
+++ b/parser/lman_parser.py
@@ -1114,7 +1114,7 @@ class Parser:
 
         return True
 
-    def run(self, skip_first_run=False):
+    def run(self, skip_first_run=False, run_validation=False):
         time1 = time.time()
         self.write_generic_files = True
         self.process_contents_page()
@@ -1142,13 +1142,14 @@ class Parser:
         logging.info(f"Run 2 took {time3-time2:.1f} seconds")
         logging.debug("Dictionary of links:")
         logging.debug(pformat(self.link_tracker))
-        validator_time, publish_time = self.run_dita_command()
+        validator_time, publish_time = self.run_dita_command(run_validator=run_validation)
         time4 = time.time()
         logging.info("Timings:")
         if not skip_first_run:
             logging.info(f"Run 1: {time2-time1:.1f} seconds")
         logging.info(f"Run 2: {time3-time2:.1f} seconds")
-        logging.info(f"DITA validator: {validator_time:.1f} seconds")
+        if run_validation:
+            logging.info(f"DITA validator: {validator_time:.1f} seconds")
         logging.info(f"DITA publish: {publish_time:.1f} seconds")
         logging.info(f"Total: {time4-time1:.1f} seconds")
 
@@ -1171,6 +1172,11 @@ def init_argparse():
         "--warn-on-blank-runs",
         action=argparse.BooleanOptionalAction,
         help="Print warning messages whenever runs of blank paragraphs are found",
+    )
+    parser.add_argument(
+        "--run-validation",
+        action=argparse.BooleanOptionalAction,
+        help="Run the DITA validation step",
     )
     return parser
 
@@ -1209,4 +1215,4 @@ if __name__ == "__main__":
     parser = Parser(Path(root_path).resolve(), Path(target_dir) / "regions")
     parser.warn_on_blank_runs = args.warn_on_blank_runs
 
-    parser.run(args.skip_first_run)
+    parser.run(args.skip_first_run, args.run_validation)

--- a/parser/parse_single_file.py
+++ b/parser/parse_single_file.py
@@ -18,30 +18,23 @@ def parse_single_file(root_path, file_path, target_path):
     os.makedirs("target", exist_ok=True)
     target_dir = os.path.join("target", "dita")
 
-    # copy index.dita and welcome.dita from data dir to target/dita
-
+    time1 = time.time()
     parser = Parser(Path(root_path).resolve(), Path(target_dir) / "regions")
     parser.only_process_single_file = True
-
-    time1 = time.time()
-    parser.write_generic_files = False
-    parser.process_regions()
-    time2 = time.time()
-    logging.info("Done run 1")
-    logging.info(f"Run 1 took {time2-time1:.2} seconds")
-
-    parser.files_already_processed = set()
     parser.write_generic_files = True
+    ret_val = parser.load_link_tracker()
+    if not ret_val:
+        sys.exit()
 
     output_dita_filename = parser.process_generic_file(Path(file_path).resolve())
-    time3 = time.time()
+    time2 = time.time()
     logging.info("Done run 2 for single file")
-    logging.info(f"Run 2 took {time3-time2:.2} seconds")
+    logging.info(f"Run 2 took {time2-time1:.2} seconds")
 
     parser.run_dita_command(output_dita_filename, run_validator=False)
-    time4 = time.time()
+    time3 = time.time()
 
-    logging.info(f"Running DITA to HTML conversion took {time4-time3:.2} seconds")
+    logging.info(f"Running DITA to HTML conversion took {time3-time2:.2} seconds")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR includes two main changes:

- Storing the link tracker (ie. 'shopping list') in a JSON file called `link_tracker.json` and use that when processing single files using the `parse_single_file.py` script so we don't have to run Run 1 in that case
- Extending the command-line arguments that can be used on the main parser script. The new `--help` output is below:

```
usage: lman_parser.py [OPTION] DATA_PATH [LOGGING_LEVEL]

positional arguments:
  DATA_PATH             Path to the source data
  LOGGING_LEVEL         Debug level - must be one of debug, warning or info

options:
  -h, --help            show this help message and exit
  --skip-first-run, --no-skip-first-run
                        Skip Run 1, loading the shopping list from the link_tracker.json file
  --warn-on-blank-runs, --no-warn-on-blank-runs
                        Print warning messages whenever runs of blank paragraphs are found
```

This includes two new options:
- `--skip-first-run` will skip doing Run 1, and use the data from link_tracker.json instead
- `--warn-on-blank-runs` will show warnings for situations where there are runs of <p> tags just containing blank space

Both of these options are off by default, and are turned on by providing that command-line switch.

This PR makes running for single files work properly for the first time (we don't have to use nasty hacks now we're using the link_tracker.json file), and should enable clearing up the output (by removing blank tags warnings unless we turn them on) and speedier iteration (by skipping the first run when requested).

Happy to change the name of any of the CLI params if you want - just let me know.