### PR TITLE
Hotfix breaking parser

### DIFF
--- a/data/Britain.Legacy/Phase_G_Size.html
+++ b/data/Britain.Legacy/Phase_G_Size.html
@@ -71,8 +71,8 @@
         </div>
         <!-- the next link is a real instance of an anchor target being placed within the relevant content.
         The fact the anchor overlaps with the next h1 is true, too.-->
-        <a name="number2">
-            <h1><strong>ANCHOR PROPULSION SYSTEM</strong></h1></a></h1>
+        <a name="number2"></a>
+            <h1><strong>ANCHOR PROPULSION SYSTEM</strong></h1></h1>
             <p>9.&nbsp;&nbsp;&nbsp;Nisi anim nisi ea ad est nostrud elit velit exercitation labore ipsum cillum labore. Consectetur minim elit ipsum qui consectetur occaecat. Est sit reprehenderit adipisicing reprehenderit officia aute et do dolor sunt Lorem amet. Labore sint laboris ullamco velit laborum officia aliqua proident aliquip.</p>
             <p>10.&nbsp;&nbsp;&nbsp;<strong>Multi-Phase polarity decoupling</strong> Veniam incididunt adipisicing ex cupidatat. Et sit ad Lorem ad eiusmod exercitation Lorem quis nulla. Dolore ullamco sunt eiusmod commodo anim eiusmod irure duis cillum incididunt elit adipisicing ad. Eiusmod veniam labore occaecat minim voluptate Lorem cupidatat. Magna non ad veniam enim consequat labore eu.</p>
             <p>11.&nbsp;&nbsp;&nbsp;<strong>Cat b Engine R</strong> This type of engine repeatedly incididunt adipisicing ex cupidatat. Et sit ad Lorem ad eiusmod exercitation Lorem quis nulla. Dolore ullamco sunt eiusmod commodo anim eiusmod irure duis cillum incididunt elit adipisicing ad. Eiusmod veniam labore occaecat minim voluptate Lorem cupidatat. Magna non ad veniam enim consequat labore eu.</p>

--- a/data/Britain_Cmplx/Britain_Cmplx1.html
+++ b/data/Britain_Cmplx/Britain_Cmplx1.html
@@ -91,7 +91,7 @@
           <td>Unk</td>
         </tr>
         <tr>
-          <td><strong></strong><span style="color: #F00; font-size: 16pt">*</span><strong>>Unit Foxtrot Alpha</td>
+          <td><strong></strong><span style="color: #F00; font-size: 16pt">*</span><strong>Unit Foxtrot Alpha</td>
           <td>PBF</td>
           <td>2 * V6 Diesel</td>
           <td>2 * 4 (FPP)</td>

--- a/data/Britain_Cmplx/Britain_Cmplx1.html
+++ b/data/Britain_Cmplx/Britain_Cmplx1.html
@@ -70,7 +70,7 @@
           <td colspan="6">This has a different cooling system to that originally purchased. See the Thorpe <a href="./Bravo_Transducer.html">P6643</a> specification</td>
         </tr>
         <tr>
-          <td colspan="7"><a id="hydraulic_installations">Hydraulic</a></td>
+          <td colspan="7"><strong><a name="number2"></a>Hydraulic</strong></td>
         </tr>
         <tr>
           <td><a href="unit_anchors.html">Unit Anchors</a></td>

--- a/data/Britain_Cmplx/Britain_Cmplx1.html
+++ b/data/Britain_Cmplx/Britain_Cmplx1.html
@@ -60,7 +60,7 @@
         <tr>
           <td rowspan="2"><a href="unit_banjo.html">Unit Banjo</a></td>
           <td>PBF</td>
-          <td>2 * V6 Diesel</td>
+          <td>2 * V6 Diesel<br/>Mild Hybrid</td>
           <td>2 * 4 (FPP)</td>
           <td>16.6</td>
           <td>Est 1000</td>

--- a/data/Britain_Cmplx/Britain_Cmplx1.html
+++ b/data/Britain_Cmplx/Britain_Cmplx1.html
@@ -70,7 +70,7 @@
           <td colspan="6">This has a different cooling system to that originally purchased. See the Thorpe <a href="./Bravo_Transducer.html">P6643</a> specification</td>
         </tr>
         <tr>
-          <td colspan="7">Hydraulic</td>
+          <td colspan="7"><a id="hydraulic_installations">Hydraulic</a></td>
         </tr>
         <tr>
           <td><a href="unit_anchors.html">Unit Anchors</a></td>

--- a/data/Britain_Cmplx/Britain_Cmplx1.html
+++ b/data/Britain_Cmplx/Britain_Cmplx1.html
@@ -49,6 +49,15 @@
           <td colspan="7">Steam Driven</td>
         </tr>
         <tr>
+          <td><img src="./Content/Images/yellow.jpg" name="image3">Aragorn</td>
+          <td>PBA</td>
+          <td>3 * V8 Diesel</td>
+          <td>2 x 3</td>
+          <td>31 Kts</td>ß
+          <td>Unk</td>
+          <td>Unk</td>
+        </tr>
+        <tr>
           <td><a href="unit_a28.html">Unit A28</a></td>
           <td>PB</td>
           <td>2 * V8 Diesel</td>

--- a/data/Britain_Cmplx/Britain_Cmplx1.html
+++ b/data/Britain_Cmplx/Britain_Cmplx1.html
@@ -73,7 +73,7 @@
           <td colspan="7"><strong><a name="number2"></a>Hydraulic</strong></td>
         </tr>
         <tr>
-          <td><a href="unit_anchors.html">Unit Anchors</a></td>
+          <td><a href="unit_anchors.html"><strong></strong><span style="color: #F00; font-size: 16pt">*</span><strong>Unit Anchors</strong></a></td>
           <td>DFD</td>
           <td>2 * V6 Diesel</td>
           <td>12 x 4</td>
@@ -82,7 +82,7 @@
           <td>Unk</td>
         </tr>
         <tr>
-          <td>Unit Foxtrot Alpha</td>
+          <td><strong></strong><span style="color: #F00; font-size: 16pt">*</span><strong>>Unit Foxtrot Alpha</td>
           <td>PBF</td>
           <td>2 * V6 Diesel</td>
           <td>2 * 4 (FPP)</td>

--- a/data/France1/FR_Phase_G_Size.html
+++ b/data/France1/FR_Phase_G_Size.html
@@ -71,8 +71,8 @@
         </div>
         <!-- the next link is a real instance of an anchor target being placed within the relevant content.
         The fact the anchor overlaps with the next h1 is true, too.-->
-        <a name="number2">
-            <h1><strong>ANCHOR PROPULSION SYSTEM</strong></h1></a></h1>
+        <a name="number2"></a>
+            <h1><strong>ANCHOR PROPULSION SYSTEM</strong></h1></h1>
             <p>9.&nbsp;&nbsp;&nbsp;Nisi anim nisi ea ad est nostrud elit velit exercitation labore ipsum cillum labore. Consectetur minim elit ipsum qui consectetur occaecat. Est sit reprehenderit adipisicing reprehenderit officia aute et do dolor sunt Lorem amet. Labore sint laboris ullamco velit laborum officia aliqua proident aliquip.</p>
             <p>10.&nbsp;&nbsp;&nbsp;<strong>Multi-Phase polarity decoupling</strong> Veniam incididunt adipisicing ex cupidatat. Et sit ad Lorem ad eiusmod exercitation Lorem quis nulla. Dolore ullamco sunt eiusmod commodo anim eiusmod irure duis cillum incididunt elit adipisicing ad. Eiusmod veniam labore occaecat minim voluptate Lorem cupidatat. Magna non ad veniam enim consequat labore eu.</p>
             <p>11.&nbsp;&nbsp;&nbsp;<strong>Cat b Engine R</strong> This type of engine repeatedly incididunt adipisicing ex cupidatat. Et sit ad Lorem ad eiusmod exercitation Lorem quis nulla. Dolore ullamco sunt eiusmod commodo anim eiusmod irure duis cillum incididunt elit adipisicing ad. Eiusmod veniam labore occaecat minim voluptate Lorem cupidatat. Magna non ad veniam enim consequat labore eu.</p>

--- a/data/Spain.Legacy/Phase_G_Size.html
+++ b/data/Spain.Legacy/Phase_G_Size.html
@@ -71,8 +71,8 @@
         </div>
         <!-- the next link is a real instance of an anchor target being placed within the relevant content.
         The fact the anchor overlaps with the next h1 is true, too.-->
-        <a name="number2">
-            <h1><strong>ANCHOR PROPULSION SYSTEM</strong></h1></a></h1>
+        <a name="number2"></a>
+            <h1><strong>ANCHOR PROPULSION SYSTEM</strong></h1></h1>
             <p>9.&nbsp;&nbsp;&nbsp;Nisi anim nisi ea ad est nostrud elit velit exercitation labore ipsum cillum labore. Consectetur minim elit ipsum qui consectetur occaecat. Est sit reprehenderit adipisicing reprehenderit officia aute et do dolor sunt Lorem amet. Labore sint laboris ullamco velit laborum officia aliqua proident aliquip.</p>
             <p>10.&nbsp;&nbsp;&nbsp;<strong>Multi-Phase polarity decoupling</strong> Veniam incididunt adipisicing ex cupidatat. Et sit ad Lorem ad eiusmod exercitation Lorem quis nulla. Dolore ullamco sunt eiusmod commodo anim eiusmod irure duis cillum incididunt elit adipisicing ad. Eiusmod veniam labore occaecat minim voluptate Lorem cupidatat. Magna non ad veniam enim consequat labore eu.</p>
             <p>11.&nbsp;&nbsp;&nbsp;<strong>Cat b Engine R</strong> This type of engine repeatedly incididunt adipisicing ex cupidatat. Et sit ad Lorem ad eiusmod exercitation Lorem quis nulla. Dolore ullamco sunt eiusmod commodo anim eiusmod irure duis cillum incididunt elit adipisicing ad. Eiusmod veniam labore occaecat minim voluptate Lorem cupidatat. Magna non ad veniam enim consequat labore eu.</p>

--- a/data/Wales.Legacy/Phase_G_Size.html
+++ b/data/Wales.Legacy/Phase_G_Size.html
@@ -71,8 +71,8 @@
         </div>
         <!-- the next link is a real instance of an anchor target being placed within the relevant content.
         The fact the anchor overlaps with the next h1 is true, too.-->
-        <a name="number2">
-            <h1><strong>ANCHOR PROPULSION SYSTEM</strong></h1></a></h1>
+        <a name="number2"></a>
+            <h1><strong>ANCHOR PROPULSION SYSTEM</strong></h1></h1>
             <p>9.&nbsp;&nbsp;&nbsp;Nisi anim nisi ea ad est nostrud elit velit exercitation labore ipsum cillum labore. Consectetur minim elit ipsum qui consectetur occaecat. Est sit reprehenderit adipisicing reprehenderit officia aute et do dolor sunt Lorem amet. Labore sint laboris ullamco velit laborum officia aliqua proident aliquip.</p>
             <p>10.&nbsp;&nbsp;&nbsp;<strong>Multi-Phase polarity decoupling</strong> Veniam incididunt adipisicing ex cupidatat. Et sit ad Lorem ad eiusmod exercitation Lorem quis nulla. Dolore ullamco sunt eiusmod commodo anim eiusmod irure duis cillum incididunt elit adipisicing ad. Eiusmod veniam labore occaecat minim voluptate Lorem cupidatat. Magna non ad veniam enim consequat labore eu.</p>
             <p>11.&nbsp;&nbsp;&nbsp;<strong>Cat b Engine R</strong> This type of engine repeatedly incididunt adipisicing ex cupidatat. Et sit ad Lorem ad eiusmod exercitation Lorem quis nulla. Dolore ullamco sunt eiusmod commodo anim eiusmod irure duis cillum incididunt elit adipisicing ad. Eiusmod veniam labore occaecat minim voluptate Lorem cupidatat. Magna non ad veniam enim consequat labore eu.</p>

--- a/parser/html_to_dita.py
+++ b/parser/html_to_dita.py
@@ -248,12 +248,14 @@ def htmlToDITA(soup_in, dita_soup, topic_id, div_replacement="span", wrap_string
 
     # 5b. Fix anchors (a without href attribute)
     # TODO: handle this instance in Issue #288
-    # We actually convert them to <div> elements now, in case they have something inside them
+    # We actually convert them to <b> elements now, in case they have something inside them
     # (which they do in Phase_F_Size.html (ref a3b) - where a heading and more is inside)
     for a in soup.find_all("a", {"href": False}):
-        a.name = "div"
-        a["id"] = a["name"]
-        del a["name"]
+        # move name to id, if present - that's the modern structure of an href
+        if a.has_attr("name"):
+            a["id"] = a["name"]
+            del a["name"]
+        a.name = "b"
 
     # 6. Remove <br> newlines
     for br in soup.find_all("br"):

--- a/parser/html_to_dita.py
+++ b/parser/html_to_dita.py
@@ -257,9 +257,13 @@ def htmlToDITA(soup_in, dita_soup, topic_id, div_replacement="span", wrap_string
             del a["name"]
         a.name = "b"
 
-    # 6. Remove <br> newlines
+    # 6. Replace <br> newlines with the linebreak processing instruction
+    # todo: this converts the brackets to &lt; and &gt;.
+    # we need to find a way to make BS4 generate the processing instruction
     for br in soup.find_all("br"):
         br.decompose()
+    if soup.name.lower() == "br":
+        return "<?linebreak?>"
 
     # 8. Replace <strong> with <bold>
     for strong in soup.find_all("strong"):

--- a/parser/html_to_dita.py
+++ b/parser/html_to_dita.py
@@ -3,7 +3,7 @@ import logging
 import os
 from bs4 import BeautifulSoup
 import bs4
-from pathlib import Path
+from pathlib import Path, PurePath
 import cssutils
 import re
 from parser_utils import convert_html_href_to_dita_href, sanitise_filename, is_button_id
@@ -158,7 +158,11 @@ def htmlToDITA(soup_in, dita_soup, topic_id, div_replacement="span", wrap_string
             div.decompose()
 
     # 3. For img elements, rename it to image, and rename the src attribute to href
-    for img in soup.find_all("img"):
+    if soup.name.lower() == "img":
+        imgItems = [soup]
+    else:
+        imgItems = soup.find_all("img")
+    for img in imgItems:
         img.name = "image"
         img["href"] = img["src"]
         if "image020" in img["href"]:
@@ -308,14 +312,19 @@ def htmlToDITA(soup_in, dita_soup, topic_id, div_replacement="span", wrap_string
                 p.name = "li"
 
     # 10a. Replace `span` or `strong` used for red-formatting with a <ph> equivalent
-    for span in soup.find_all("span", recursive=True):
+    if soup.name.lower() == "span":
+        # create an array with just the soup
+        spanItems = [soup]
+    else:
+        spanItems = soup.find_all("span", recursive=True)
+    for span in spanItems:
         if span.has_attr("style"):
             style = span["style"].lower()
             if "color:" in style:
                 span.name = "ph"
-                if "#F00" in style:
+                if "#f00" in style:
                     span["outputclass"] = "colorRed"
-                elif "#00F" in style:
+                elif "#00f" in style:
                     span["outputclass"] = "colorBlue"
                 elif "#777" in style:
                     span["outputclass"] = "colorGray"
@@ -346,9 +355,9 @@ def htmlToDITA(soup_in, dita_soup, topic_id, div_replacement="span", wrap_string
     ):  # note: strong has already been converted to `b`
         if strong.has_attr("style"):
             if "color:" in strong["style"]:
-                if "#F00" in strong["style"]:
+                if "#f00" in strong["style"].lower():
                     strong["outputclass"] = "colorRed"
-                elif "#00F" in strong["style"]:
+                elif "#00f" in strong["style"].lower():
                     strong["outputclass"] = "colorBlue"
             del strong["style"]
 

--- a/parser/lman_parser.py
+++ b/parser/lman_parser.py
@@ -425,12 +425,13 @@ class Parser:
         # We have replaced that with the convert_html_table_to_dita_table as it deals with all the edge cases
         # and then taken this part out and run it separately
         for a in parent_table.find_all("a"):
-            href = a.get("href")
-            href = href.split(".html")[0] + ".html"
-            class_file_src_path = f"{self.root_path}/{os.path.dirname(remove_leading_slashes(category_page_link))}/{href}"
+            if a.has_attr("href"):
+                href = a.get("href")
+                href = href.split(".html")[0] + ".html"
+                class_file_src_path = f"{self.root_path}/{os.path.dirname(remove_leading_slashes(category_page_link))}/{href}"
 
-            if not self.only_process_single_file:
-                self.process_generic_file(class_file_src_path)
+                if not self.only_process_single_file:
+                    self.process_generic_file(class_file_src_path)
 
         dita_section.append(dita_emptytitle)
         dita_section.append(dita_table)

--- a/parser/lman_parser.py
+++ b/parser/lman_parser.py
@@ -360,6 +360,7 @@ class Parser:
         # Find a <td> with colspan=7, this indicates that the page is a category page
         td = soup.find("td", {"colspan": "7"})
         title = soup.find("h2")
+        topic_id = sanitise_filename(title.text)
 
         if td is None:
             # This used to be a workaround for not dealing with a page without a <td> with colspan 7,
@@ -417,7 +418,7 @@ class Parser:
         category_path = f"target/dita/regions/{sanitise_filename(category, directory=True)}"
         os.makedirs(category_path, exist_ok=True)
 
-        dita_table = convert_html_table_to_dita_table(parent_table, dita_soup, "")
+        dita_table = convert_html_table_to_dita_table(parent_table, dita_soup, topic_id)
 
         # Go through the original HTML table and process all the links
         # by calling process_generic_file on them
@@ -446,7 +447,7 @@ class Parser:
         dita_flagsection.append(dita_fig)
         dita_refbody.insert(0, dita_flagsection)
 
-        dita_reference["id"] = sanitise_filename(title.text)
+        dita_reference["id"] = topic_id
         dita_reference.append(dita_title)
         dita_reference.append(dita_shortdesc)
         dita_reference.append(dita_refbody)


### PR DESCRIPTION
The parser was breaking when we encounter an target anchor, rather than a link.  Fixing this introduced some other tidying up.

Fixes #574 