### PR TITLE
Buttons for contents index

### DIFF
--- a/data/QuickLinksData/Contents_Index.html
+++ b/data/QuickLinksData/Contents_Index.html
@@ -56,24 +56,11 @@
       <h1>&nbsp;</h1>
       <div style="position: absolute; visibility: visible; left: 21px; top: 1px; width: 906px;">
         <div align="center">
-          <table width="50%" border="1">
+          <table outputclass="contents-index" width="50%" border="0">
             <TR>
-              <TD width="26%" bgcolor="#999999"><strong>SUBJECT</strong></TD>
-              <TD width="11%" bgcolor="#999999"><strong>LINK</strong></TD>
-            </TR>
-            <TR>
-              <TD bgcolor="#999999"><strong>Abbreviations</strong></TD>
-              <TD><a href="../QuickLinksData/Abbreviations.html">Go To</a></TD>
-            </TR>
-            <TR>
-              <TD bgcolor="#999999"><strong>Brush Noise</strong></TD>
-              <TD><a href="../Brush Noise/Brush_Noise.html">Go to</a>
-              </TD>
-            </TR>
-            <TR>
-              <TD bgcolor="#999999"><strong>Vanes & Cranes</strong></TD>
-              <TD><a href="Vanes&Cranes.html">Go to</a>
-              </TD>
+              <TD><a outputclass="enterBtn" href="../QuickLinksData/Abbreviations.html">Abbreviations</a></TD>
+              <TD><a outputclass="enterBtn" href="../Brush Noise/Brush_Noise.html">Brush Noise</a></TD>
+              <TD><a outputclass="enterBtn" href="Vanes&Cranes.html">Vanes & Cranes</a></TD>
             </TR>
           </table>
         </div>

--- a/parser/html_to_dita.py
+++ b/parser/html_to_dita.py
@@ -451,6 +451,9 @@ def convert_html_table_to_dita_table(source_html, target_soup, topic_id):
     if source_html.has_attr("border") and source_html["border"] == "1":
         dita_table_element["frame"] = "all"
 
+    if source_html.has_attr("outputclass"):
+        dita_table_element["outputclass"] = source_html["outputclass"]
+
     # Get max number of columns in all rows
     max_num_columns = 0
     for tr in source_html.find_all("tr"):

--- a/template/F13ldMan/f13ldman.css
+++ b/template/F13ldMan/f13ldman.css
@@ -281,7 +281,7 @@ padding: 0 10px;
   font: bold 20px Arial;
 }
 
-/** just shrink the buttons on the contents page, since there are lots of them */
+/** make the contents index go full width */
 .contents-index {
   width: 100%;
 }

--- a/template/F13ldMan/f13ldman.css
+++ b/template/F13ldMan/f13ldman.css
@@ -274,7 +274,17 @@ padding: 0 10px;
 
 .enterBtn:visited {
   color: #333333;
-} 
+}
+
+/** just shrink the buttons on the contents page, since there are lots of them */
+.contents-index .enterBtn {
+  font: bold 20px Arial;
+}
+
+/** just shrink the buttons on the contents page, since there are lots of them */
+.contents-index {
+  width: 100%;
+}
 
 /*
 * ==============================================


### PR DESCRIPTION
The contents page has about 20 buttons.

I'm using the `entrybtn` styling, but they are too large.

Give the parent table a class, and then shrink the buttons.