### PR TITLE
Fix for hiding short-desc

### DIFF
--- a/template/F13ldMan/f13ldman.css
+++ b/template/F13ldMan/f13ldman.css
@@ -34,6 +34,12 @@
 }
 
 
+/* hide the `short-desc` from topic pages, since we
+  only want them on the home page */
+.shortdesc {
+  display: none;
+}  
+
 /* styling to make the `REGIONS` button twice the width of the others */
 .wh_tiles-container {
   padding: 5% 15%;


### PR DESCRIPTION
Don't show the short-desc on the topic page, reserve it for the index page.

Supports #587 