### PR TITLE
Hotfix single character cells

### DIFF
--- a/data/Britain_Cmplx/unit_a28.html
+++ b/data/Britain_Cmplx/unit_a28.html
@@ -95,7 +95,7 @@
             <td>2 * 4 (GRR)</td>
             <td>412.8:1</td>
             <td>40 kts</td>
-            <td>~14</td>
+            <td>8</td>
           </tr>
           <tr>
             <td bgcolor="#CCCCCC" colspan="6">

--- a/parser/html_to_dita.py
+++ b/parser/html_to_dita.py
@@ -572,7 +572,7 @@ def convert_html_table_to_dita_table(source_html, target_soup, topic_id):
             # strip out empty navigable strings,
             def notEmptyNav(item):
                 if type(item) is bs4.element.NavigableString:
-                    return len(item) > 1
+                    return not item.isspace() or len(item) > 1
                 return True
 
             elements = list(filter(notEmptyNav, elements))


### PR DESCRIPTION
Handle issue where cells containing a single character were being stripped empty.

If a cell contains only one character of text, only ditch it if it's whitespace.